### PR TITLE
Sanitize sql input in ParameterDAO

### DIFF
--- a/source/src/main/java/org/cerberus/crud/dao/impl/ParameterDAO.java
+++ b/source/src/main/java/org/cerberus/crud/dao/impl/ParameterDAO.java
@@ -368,14 +368,9 @@ public class ParameterDAO implements IParameterDAO {
         query.append(searchSQL);
 
         if (!StringUtil.isNullOrEmpty(column)) {
-            query.append(" order by ").append(column).append(" ").append(dir);
+            query.append(" order by ? ?");
         }
-
-        if ((amount <= 0) || (amount >= MAX_ROW_SELECTED)) {
-            query.append(" limit ").append(start).append(" , ").append(MAX_ROW_SELECTED);
-        } else {
-            query.append(" limit ").append(start).append(" , ").append(amount);
-        }
+        query.append(" limit ? , ?");
 
         // Debug message on SQL.
         if (LOG.isDebugEnabled()) {
@@ -400,7 +395,16 @@ public class ParameterDAO implements IParameterDAO {
                 for (String individualColumnSearchValue : individalColumnSearchValues) {
                     preStat.setString(i++, individualColumnSearchValue);
                 }
-
+                if (!StringUtil.isNullOrEmpty(column)) {
+                    preStat.setString(i++, column);
+                    preStat.setString(i++, dir);
+                }
+                preStat.setInt(i++, start);
+                if ((amount <= 0) || (amount >= MAX_ROW_SELECTED)) {
+                    preStat.setInt(i++, MAX_ROW_SELECTED);
+                } else {
+                    preStat.setInt(i++, amount);
+                }
                 ResultSet resultSet = preStat.executeQuery();
                 try {
                     //gets the data


### PR DESCRIPTION
This PR fixes some sql sanitization issues found by lgtm.com:
https://lgtm.com/projects/g/vertigo17/Cerberus/alerts/
(sql query built from user-control sources)
I have checked that one of the parameters can lead to unintended query being run and affect the output of the page. The alerts on the other files are similar and can be fixed in similar way. I am happy to help fixing them if the fix in this PR is suitable.
Hope this is the right way to contribute and please let me know if there's anything else I can help. Thanks.