### PR TITLE
Various fixes around KeyPress actions

### DIFF
--- a/source/src/main/java/org/cerberus/enums/KeyCodeEnum.java
+++ b/source/src/main/java/org/cerberus/enums/KeyCodeEnum.java
@@ -51,7 +51,7 @@ public enum KeyCodeEnum {
     PAUSE(11, "PAUSE", KeyEvent.VK_PAUSE),
     ESCAPE(12, "ESCAPE", KeyEvent.VK_ESCAPE),
     SPACE(13, "SPACE", KeyEvent.VK_SPACE),
-    PAGE_UP(14, "SPACE", KeyEvent.VK_PAGE_UP),
+    PAGE_UP(14, "PAGE_UP", KeyEvent.VK_PAGE_UP),
     PAGE_DOWN(15, "PAGE_DOWN", KeyEvent.VK_PAGE_DOWN),
     END(16, "END", KeyEvent.VK_END),
     HOME(17, "HOME", KeyEvent.VK_HOME),


### PR DESCRIPTION
- Fixing KeyPress issue with WebDriver due to headless application status
- Adding a way to force the focus of the browser in order to perform KeyPress actions (only for Windows)
- Fixing wrong keycode for PAGE_UP

Note : KeyPress action seems to only work when Cerberus and Selenium instances are running on the same environment due to Robot use, disabling by the way the ability to use a remote Selenium and having a graphical environment mandatory. More, the KeyPress action needs the browser windows to be focused in order to work and so far only a way for Microsoft Windows is implemented here.