### PR TITLE
Docker cerberus-as-glassfish 3.3 : container in error, problem with default pwd

### DIFF
--- a/docker/images/cerberus-as-glassfish/3.3/entrypoint.sh
+++ b/docker/images/cerberus-as-glassfish/3.3/entrypoint.sh
@@ -54,8 +54,7 @@ function setup() {
     local ASADMIN_DEFAULT=asadmin
     ${ASADMIN_DEFAULT} start-domain ${GLASSFISH_DOMAIN}
 
-    echo "AS_ADMIN_PASSWORD=admin" > /tmp/glassfishpwd
-    echo "AS_ADMIN_NEWPASSWORD=${GLASSFISH_ADMIN_PASSWORD}" >> /tmp/glassfishpwd
+    cat /tmp/glassfish_admin_set_password.txt > /tmp/glassfishpwd
     ${ASADMIN_DEFAULT} --user ${GLASSFISH_ADMIN_USER} --passwordfile /tmp/glassfishpwd change-admin-password --domain_name ${GLASSFISH_DOMAIN}
     rm /tmp/glassfishpwd
     echo "AS_ADMIN_PASSWORD=${GLASSFISH_ADMIN_PASSWORD}" > /tmp/glassfishpwd


### PR DESCRIPTION
Hi, 

With the cerberus-as-glassfish tag 3.3 docker image, i have an error concerning the change-admin-password instruction. Container refuse to start with the following error (infinite loop).
It happens on my personal laptop and in the rancher at my work too.

```
* Starting Cerberus Glassfish setup...
Waiting for domain1 to start .....
Successfully started the domain : domain1
domain  Location: /glassfish5/glassfish/domains/domain1
Log File: /glassfish5/glassfish/domains/domain1/logs/server.log
Admin Port: 4848
Command start-domain executed successfully.
Authorization has been refused for credentials [user: admin] given in this request.
(Usually, this means invalid user name and/or password)
Command change-admin-password failed.
```
Problem comes from the part `echo "AS_ADMIN_PASSWORD=admin" > /tmp/glassfishpwd`  in the `entrypoint.sh` file (default password is empty, not admin)
I propose to use the file `glassfish_admin_set_password.txt` included in the image instead.

Regards,