### PR TITLE
chrome correction

### DIFF
--- a/source/src/main/java/org/cerberus/engine/execution/impl/SeleniumServerService.java
+++ b/source/src/main/java/org/cerberus/engine/execution/impl/SeleniumServerService.java
@@ -332,11 +332,14 @@ public class SeleniumServerService implements ISeleniumServerService {
                  */
                 String targetScreensize = getScreenSizeToUse(tCExecution.getTestCaseObj().getScreenSize(), tCExecution.getScreenSize());
                 LOG.debug("Selenium resolution : " + targetScreensize);
-                if ((!StringUtil.isNullOrEmpty(targetScreensize)) && targetScreensize.contains("*")) {
-                    Integer screenWidth = Integer.valueOf(targetScreensize.split("\\*")[0]);
-                    Integer screenLength = Integer.valueOf(targetScreensize.split("\\*")[1]);
-                    setScreenSize(driver, screenWidth, screenLength);
-                    LOG.debug("Selenium resolution Activated : " + screenWidth + "*" + screenLength);
+                
+                if(!tCExecution.getBrowser().equalsIgnoreCase("chrome")) {
+	                if ((!StringUtil.isNullOrEmpty(targetScreensize)) && targetScreensize.contains("*")) {
+	                    Integer screenWidth = Integer.valueOf(targetScreensize.split("\\*")[0]);
+	                    Integer screenLength = Integer.valueOf(targetScreensize.split("\\*")[1]);
+	                    setScreenSize(driver, screenWidth, screenLength);
+	                    LOG.debug("Selenium resolution Activated : " + screenWidth + "*" + screenLength);
+	                }
                 }
                 tCExecution.setScreenSize(getScreenSize(driver));
                 tCExecution.setRobotDecli(tCExecution.getRobotDecli().replace("%SCREENSIZE%", tCExecution.getScreenSize()));
@@ -584,7 +587,19 @@ public class SeleniumServerService implements ISeleniumServerService {
                  */
                 ChromeOptions options = new ChromeOptions();
                 // Maximize windows for chrome browser
+               
+                String targetScreensize = getScreenSizeToUse(tCExecution.getTestCaseObj().getScreenSize(), tCExecution.getScreenSize());
+              
+                if ((!StringUtil.isNullOrEmpty(targetScreensize)) && targetScreensize.contains("*")) {
+                  Integer screenWidth = Integer.valueOf(targetScreensize.split("\\*")[0]);
+                  Integer screenLength = Integer.valueOf(targetScreensize.split("\\*")[1]);
+                  String sizeOpts = "--window-size=" + screenWidth + "," + screenLength;
+                  options.addArguments(sizeOpts);
+                  LOG.debug("Selenium resolution Activated : " + screenWidth + "*" + screenLength);
+              
+                }
                 options.addArguments("start-maximized");
+                options.addArguments("--headless");               
                 // Set UserAgent if necessary
                 String usedUserAgent = getUserAgentToUse(tCExecution.getTestCaseObj().getUserAgent(), tCExecution.getUserAgent());
                 if (!StringUtil.isNullOrEmpty(usedUserAgent)) {

--- a/source/src/main/java/org/cerberus/engine/execution/impl/SeleniumServerService.java
+++ b/source/src/main/java/org/cerberus/engine/execution/impl/SeleniumServerService.java
@@ -333,7 +333,7 @@ public class SeleniumServerService implements ISeleniumServerService {
                 String targetScreensize = getScreenSizeToUse(tCExecution.getTestCaseObj().getScreenSize(), tCExecution.getScreenSize());
                 LOG.debug("Selenium resolution : " + targetScreensize);
                 
-                if(!tCExecution.getBrowser().equalsIgnoreCase("chrome")) {
+                if(!tCExecution.getBrowser().equalsIgnoreCase(BrowserType.CHROME)) {
 	                if ((!StringUtil.isNullOrEmpty(targetScreensize)) && targetScreensize.contains("*")) {
 	                    Integer screenWidth = Integer.valueOf(targetScreensize.split("\\*")[0]);
 	                    Integer screenLength = Integer.valueOf(targetScreensize.split("\\*")[1]);


### PR DESCRIPTION
The following error is raised when a specific size is choosen in a Cerberus robot. The execution report will fail with this message. Several tests has been done, and the error is triggered systematically :

**The test case failed to be executed. Could not start Robot Server. org.openqa.selenium.WebDriverException: unknown error: failed to change window state to normal, current state is maximized**

Configuration :

- Cerberus on glassfish 4 ( 3.10, 3.11, 3.12-snapshot )
- Selenium , selenium/standalone-chrome:3.141.59-mercury image on docker ( version 18.09.4, build d14af54266 )

It comes from the fact that the chrome node is started maximized and thus , cannot be set at the desired dimension. I tried several configuration of Selenium node and robot without success.

The provided fix sets the dimension and maximize command as chrome options, if the screen size is defined in robot configuration panel. It also disable the setcreensize() call that comes afterwards, specifically for the chrome browser, as the size is passed in node start option.

Feel free to contact me if needed. 